### PR TITLE
docs: doom+gptel instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -758,3 +758,29 @@
       ;; (custom-set-variables '(gptel-directives (gjg/gptel-build-directives "~/projects/ai/AIPIHKAL/system-prompts/")))
       (setq gptel-directives (gjg/gptel-build-directives "~/projects/ai/AIPIHKAL/system-prompts/"))
     #+end_src
+
+** Doom Emacs Setup
+
+For Doom Emacs users, you can add the following configuration to your =~/.doom.d/config.el= file to set up ~gptel-directives~ with AIPIHKAL ~system-prompts~ folder path :
+
+#+begin_src emacs-lisp
+(use-package! gptel
+  :config
+  ;; classic gptel configuration
+  (setq
+   gptel-model 'claude-3-opus-20240229
+   gptel-backend (gptel-make-anthropic "Claude"
+                   :stream t :key "sk-..."))
+  ;; set gptel-directives as AIPIHKAL system-prompts  
+  (let ((build-directives-fun "~/projects/ai/AIPIHKAL/gptel-build-directives.el"))
+    (when (file-exists-p build-directives-fun)
+      (load build-directives-fun)
+      (setq gptel-directives (gjg/gptel-build-directives "~/projects/ai/AIPIHKAL/system-prompts/")
+            gptel-system-message (alist-get 'default gptel-directives)))))
+#+end_src
+
+*** Important Notes
+
+- Replace ="sk-..."= with your actual Anthropic API key.
+- Adjust the paths for =build-directives-fun= and the system prompts directory to match your setup.
+- Make sure you have [[https://github.com/karthink/gptel][gptel]] installed in Emacs.


### PR DESCRIPTION
Include doom emacs setup instructions to set AIPIHKAL system-prompts as directives for gptel.